### PR TITLE
[FIX] Added necessarry deps for postgres and sqlite drivers

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -26,21 +26,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v6
-        if: matrix.php != '8.4'
         with:
           context: ${{ matrix.php }}/apache
           file: ${{ matrix.php }}/apache/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.php }}-apache-amd64
-      - name: Build and push latest
-        uses: docker/build-push-action@v6
-        if: matrix.php == '8.4'
-        with:
-          context: ${{ matrix.php }}/apache
-          file: ${{ matrix.php }}/apache/Dockerfile
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.php }}-apache-amd64, ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest-amd64
-  
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.php }}-apache-amd64
+            ${{ matrix.php == '8.4' && format('{0}/{1}:latest-amd64', secrets.DOCKERHUB_USERNAME, env.IMAGE_NAME) || '' }}
+
   build-arm64:
     strategy:
       matrix:
@@ -59,20 +52,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v6
-        if: matrix.php != '8.4'
         with:
           context: ${{ matrix.php }}/apache
           file: ${{ matrix.php }}/apache/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.php }}-apache-arm64
-      - name: Build and push latest
-        uses: docker/build-push-action@v6
-        if: matrix.php == '8.4'
-        with:
-          context: ${{ matrix.php }}/apache
-          file: ${{ matrix.php }}/apache/Dockerfile
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.php }}-apache-arm64, ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest-arm64
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ matrix.php }}-apache-arm64
+            ${{ matrix.php == '8.4' && format('{0}/{1}:latest-arm64', secrets.DOCKERHUB_USERNAME, env.IMAGE_NAME) || '' }}
 
   create-manifests:
     strategy:

--- a/8.4/apache/Dockerfile
+++ b/8.4/apache/Dockerfile
@@ -49,6 +49,8 @@ RUN apt-get update && \
         jq \
         gosu \
         locales \
+        libpq5 \
+        libsqlite3-0 \
     && \
     rm -rf /var/lib/apt/lists/* && \
     # Setup common locales.

--- a/8.4/apache/Dockerfile
+++ b/8.4/apache/Dockerfile
@@ -13,6 +13,8 @@ RUN savedAptMark="$(apt-mark showmanual)" && \
         libicu-dev \
         libyaml-dev \
         libzip-dev \
+        libpq-dev \
+        libsqlite3-dev \
     && \
     rm -rf /var/lib/apt/lists/* && \
     export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" && \
@@ -25,7 +27,7 @@ RUN savedAptMark="$(apt-mark showmanual)" && \
         --with-avif \
     && \
     docker-php-ext-configure intl --enable-intl && \
-    docker-php-ext-install gd mysqli opcache zip intl pdo pdo_mysql exif && \
+    docker-php-ext-install gd mysqli pgsql opcache zip intl pdo pdo_mysql pdo_pgsql pdo_sqlite exif && \
     docker-php-ext-enable apcu yaml && \
     apt-mark auto '.*' > /dev/null && \
     apt-mark manual $savedAptMark && \


### PR DESCRIPTION
I encountered the following error while trying to use this image to deploy a typo3 instance that uses a postgres database:
```
Setting up TYPO3...
In SetupCommand.php line 373:

  The connection type "postgres" does not exist. Please use one of the following mysqli, mysqliSocket, pdoMysql, pdoMysqlSocket, postgres, sqlite
```

It turned out that the php deps were missing: https://github.com/TYPO3/typo3/blob/main/typo3/sysext/install/Classes/SystemEnvironment/DatabaseCheck.php#L286